### PR TITLE
Fix GitHub Pages deployment paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Build and Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+        env:
+          NODE_ENV: production
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './docs'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -51,5 +51,6 @@ export const config = {
     dir: {
         input: "src",
         output: "docs"
-    }
+    },
+    pathPrefix: process.env.NODE_ENV === 'production' ? '/pagelove-org-site' : ''
 }

--- a/src/_includes/default.liquid
+++ b/src/_includes/default.liquid
@@ -7,7 +7,7 @@
         {% if head.stylesheet %}
             {% render head.stylesheet %}
         {% endif %}
-        <link rel="stylesheet" href="/css/style.css">
+        <link rel="stylesheet" href="{{ '/css/style.css' | url }}">
         {% if head.script %}
             {% render head.script %}
         {% endif %}


### PR DESCRIPTION
## Summary
• Fixed asset path issues causing broken CSS on GitHub Pages deployment
• Configured proper pathPrefix for subdirectory hosting (`/pagelove-org-site/`)
• Added GitHub Actions workflow for automated deployment
• Updated CSS path in Liquid template to use Eleventy url filter

## Issues Fixed
- CSS not loading (was looking for `/css/style.css` instead of `/pagelove-org-site/css/style.css`)
- Site displaying as unstyled HTML on https://pagelove.github.io/pagelove-org-site/

## Changes Made
- **eleventy.config.mjs**: Added pathPrefix configuration for production builds
- **default.liquid**: Updated CSS link to use `{{ '/css/style.css' | url }}` filter
- **.github/workflows/deploy.yml**: Added automated deployment workflow with NODE_ENV=production

## Test Plan
- [ ] Verify site loads correctly at https://pagelove.github.io/pagelove-org-site/
- [ ] Check CSS styling is applied properly
- [ ] Confirm responsive design displays correctly

@jamesread Please review and merge to fix the live site deployment. The site should display properly with correct styling once this is merged.

🤖 Generated with [Claude Code](https://claude.ai/code)